### PR TITLE
Added shortened URLs to the news command

### DIFF
--- a/Processor/Gemfile
+++ b/Processor/Gemfile
@@ -3,4 +3,4 @@ source 'http://rubygems.org'
 
 gem 'bunny'
 gem 'mongo'
-
+gem 'crack/xml'


### PR DESCRIPTION
This is mostly untested. The block of code I added in the news command works on its own, outside of faz, but since I don't really have a way to run faz itself, its not been fully tested.